### PR TITLE
Make s2ram_check_kms find card1

### DIFF
--- a/s2ram.c
+++ b/s2ram.c
@@ -58,7 +58,7 @@ int s2ram_check_kms(void)
 		return errno;
 
 	while ((dentry = readdir(sysfs_dir))) {
-		if (!strncmp(dentry->d_name, "card0-", 6)) {
+		if (!strncmp(dentry->d_name, "card", 4)) {
 			ret = 0;
 			break;
 		}


### PR DESCRIPTION
Hello!

I have a laptop with a layout like this:
```
# find /sys/class/drm
/sys/class/drm
/sys/class/drm/renderD128
/sys/class/drm/card1
/sys/class/drm/card1-HDMI-A-1
/sys/class/drm/card1-DP-2
/sys/class/drm/card1-eDP-1
/sys/class/drm/version
/sys/class/drm/card1-DP-1
```

Where s2ram does this:
```
# s2ram 
Machine is unknown.
This machine can be identified by:
    sys_vendor   = ""
    sys_product  = ""
    sys_version  = ""
    bios_version = ""

# s2ram -K
This kernel doesn't have KMS support.
```

This patch fixes the issue for me. 

Thanks!